### PR TITLE
accelerate sim_matrix process in multi-GPU

### DIFF
--- a/main_task_retrieval.py
+++ b/main_task_retrieval.py
@@ -265,8 +265,6 @@ def train_epoch(epoch, args, model, train_dataloader, device, n_gpu, optimizer, 
         input_ids, input_mask, segment_ids, video, video_mask = batch
         loss = model(input_ids, segment_ids, input_mask, video, video_mask)
 
-        if n_gpu > 1:
-            loss = loss.mean()  # mean() to average on multi-gpu.
         if args.gradient_accumulation_steps > 1:
             loss = loss / args.gradient_accumulation_steps
 

--- a/modules/modeling.py
+++ b/modules/modeling.py
@@ -260,13 +260,19 @@ class CLIP4Clip(CLIP4ClipPreTrainedModel):
 
         sequence_output, visual_output = self.get_sequence_visual_output(input_ids, token_type_ids, attention_mask,
                                                                          video, video_mask, shaped=True, video_frame=video_frame)
-
+        positive_pos = 0
         if self.training:
             loss = 0.
             sim_matrix, *_tmp = self.get_similarity_logits(sequence_output, visual_output, attention_mask, video_mask,
                                                     shaped=True, loose_type=self.loose_type)
-            sim_loss1 = self.loss_fct(sim_matrix)
-            sim_loss2 = self.loss_fct(sim_matrix.T)
+
+            # if train on multi-GPU, aligning the positive samples in local batch except 0th GPU
+            # Ensuring the tensor.diag() in loss_fn will get the right positive samples
+            if self.task_config.n_gpu != 1:
+                positive_pos = self.task_config.local_rank * sim_matrix[0].shape[0]
+
+            sim_loss1 = self.loss_fct(sim_matrix[0], positive_pos)
+            sim_loss2 = self.loss_fct(sim_matrix[1], positive_pos)
             sim_loss = (sim_loss1 + sim_loss2) / 2
             loss += sim_loss
 
@@ -383,12 +389,6 @@ class CLIP4Clip(CLIP4ClipPreTrainedModel):
             visual_output = visual_output.permute(1, 0, 2)  # LND -> NLD
             visual_output = visual_output + visual_output_original
 
-        if self.training:
-            visual_output = allgather(visual_output, self.task_config)
-            video_mask = allgather(video_mask, self.task_config)
-            sequence_output = allgather(sequence_output, self.task_config)
-            torch.distributed.barrier()
-
         visual_output = visual_output / visual_output.norm(dim=-1, keepdim=True)
         visual_output = self._mean_pooling_for_similarity_visual(visual_output, video_mask)
         visual_output = visual_output / visual_output.norm(dim=-1, keepdim=True)
@@ -397,6 +397,16 @@ class CLIP4Clip(CLIP4ClipPreTrainedModel):
         sequence_output = sequence_output / sequence_output.norm(dim=-1, keepdim=True)
 
         logit_scale = self.clip.logit_scale.exp()
+
+        # https://github.com/openai/CLIP/issues/132
+        if self.training:
+            all_visual_output = allgather(visual_output, self.task_config)
+            all_sequence_output = allgather(sequence_output, self.task_config)
+            torch.distributed.barrier()
+            retrieve_logits1 = logit_scale * torch.matmul(sequence_output, all_visual_output.t())
+            retrieve_logits2 = logit_scale * torch.matmul(visual_output, all_sequence_output.t())
+            return [retrieve_logits1, retrieve_logits2]
+
         retrieve_logits = logit_scale * torch.matmul(sequence_output, visual_output.t())
         return retrieve_logits
 

--- a/modules/until_module.py
+++ b/modules/until_module.py
@@ -183,9 +183,9 @@ class CrossEn(nn.Module):
     def __init__(self,):
         super(CrossEn, self).__init__()
 
-    def forward(self, sim_matrix):
+    def forward(self, sim_matrix, positive_pos=0):
         logpt = F.log_softmax(sim_matrix, dim=-1)
-        logpt = torch.diag(logpt)
+        logpt = torch.diag(logpt, positive_pos)
         nce_loss = -logpt
         sim_loss = nce_loss.mean()
         return sim_loss


### PR DESCRIPTION
I edit two main things:

1. Deleting the "loss.mean()" that do nothing. DDP provides automatically gradient synchronization.

2. Refer to this comment, https://github.com/openai/CLIP/issues/132#issuecomment-908004353 we will do every similarity calculation locally. This will use all negative samples in global batch and positive samples in local batch, so local sim_matrix will be shaped in **(batch_size / n_gpu, batch_size).** 

* But this approach will cause another question that if the loss function always put the first local-batch-size columns as the diagonal elements, and local batch is not the first in global, the correct postive samples will locating at column range: **local_rank * local_batch_size - (local_rank + 1) * local_batch_size**. So i give the second parameter in torch.diag() which means the first positive sample's column.

By experiments, the model can converge as usual, and more efficient.